### PR TITLE
Fix: Removed filtering hash part in subscription link

### DIFF
--- a/frontend/src/shared/utils/construct-subscription-url/construct-subscription-url.tsx
+++ b/frontend/src/shared/utils/construct-subscription-url/construct-subscription-url.tsx
@@ -4,7 +4,6 @@ export const constructSubscriptionUrl = (currentUrl: string, shortUuid: string):
     const url = parseURL(currentUrl)
 
     url.search = ''
-    url.hash = ''
     url.auth = ''
 
     const segments = url.pathname.split('/').filter(Boolean)


### PR DESCRIPTION
Removed filtering of the hash section from subscriptionUrl.